### PR TITLE
Adding automatic testing

### DIFF
--- a/misc/all_tests.conf
+++ b/misc/all_tests.conf
@@ -1,0 +1,2 @@
+include misc/host_tests.conf
+include subset/network/build.conf

--- a/subset/network/build.conf
+++ b/subset/network/build.conf
@@ -1,0 +1,5 @@
+build subset/network
+add dhcplong
+add netmin
+add netapp
+add ntpupdate

--- a/testing/test_aux.sh
+++ b/testing/test_aux.sh
@@ -22,6 +22,7 @@ fail_hook=misc/dump_network.sh
 test_config=misc/runtime_configs/long_wait
 site_path=misc/test_site
 site_report=local/tmp
+host_tests=misc/all_tests.conf
 EOF
 DAQ_FAUX1_OPTS=brute DAQ_FAUX2_OPTS=nobrute cmd/run -s
 tail -qn 1 inst/run-port-*/nodes/brute*/tmp/report.txt | tee -a $TEST_RESULTS


### PR DESCRIPTION
We need to do something like this to get the tests themselves tested. This is just a foundation, still needs to be cleaned up and we need to figure out how to test the actual functionality. 

You can/should just pull this into your working version.

If you look at [a sample test run](https://travis-ci.org/grafnu/daq/jobs/516230535), you'll see there's a number of base errors, and then also need to get it registering the results out from this specific test.